### PR TITLE
Add AlwaysIncludePSK config option to force PSK extension inclusion

### DIFF
--- a/common.go
+++ b/common.go
@@ -710,6 +710,12 @@ type Config struct {
 	// this behavior at their own discretion.
 	OmitEmptyPsk bool // [uTLS]
 
+	// AlwaysIncludePSK controls whether the PreSharedKey extension is always
+	// included in the ClientHello if there is a cached session, even if not specified 
+	// in the selected ClientHelloSpec. If there are no cached sessions, OmitEmptyPsk 
+	// controls whether the extension is omitted.
+	AlwaysIncludePSK bool // [uTLS]
+
 	// InsecureServerNameToVerify is used to verify the hostname on the returned
 	// certificates. It is intended to use with spoofed ServerName.
 	// If InsecureServerNameToVerify is "*", crypto/tls will do normal

--- a/u_parrots.go
+++ b/u_parrots.go
@@ -2626,6 +2626,23 @@ func (uconn *UConn) ApplyPreset(p *ClientHelloSpec) error {
 		return err
 	}
 
+	// Add PSK extension if not specified in the spec.
+	if uconn.config.AlwaysIncludePSK {
+		supportsPSK := uconn.config.MaxVersion >= VersionTLS13
+		if supportsPSK {
+			hasPskExt := false
+			for _, ext := range p.Extensions {
+				if _, ok := ext.(PreSharedKeyExtension); ok {
+					hasPskExt = true
+				}
+			}
+			if !hasPskExt {
+				// pre_shared_key must be the last extension (RFC 8446, Section 4.2.11).
+				p.Extensions = append(p.Extensions, &UtlsPreSharedKeyExtension{})
+			}
+		}
+	}
+
 	privateHello, ech, err := uconn.makeClientHelloForApplyPreset()
 	if err != nil {
 		return err


### PR DESCRIPTION
Previously, uTLS adds the pre_shared_key extension only when explicitly defined in the ClientHelloSpec. Given the widespread use of PSKs, this change introduces `AlwaysIncludePSK` option to decouple extension inclusion from the spec and ensure it's always added when a cached session exists.